### PR TITLE
Update contact page layout and map styling

### DIFF
--- a/src/components/ValueProp/ValueProp.jsx
+++ b/src/components/ValueProp/ValueProp.jsx
@@ -1,12 +1,18 @@
 import styles from "./ValueProp.module.css";
 
-function ValueProp({ img, iframe, children, reverse }) {
+function ValueProp({ img, iframe, children, reverse, mediaClassName }) {
   // Choose the media: prefer iframe when provided and no img is passed
   const media =
     iframe && !img ? (
-      <div className={styles.imageColumn}>{iframe}</div>
+      <div className={`${styles.imageColumn} ${mediaClassName || ""}`}>
+        {iframe}
+      </div>
     ) : img ? (
-      <img className={styles.imageColumn} src={img} alt="" />
+      <img
+        className={`${styles.imageColumn} ${mediaClassName || ""}`}
+        src={img}
+        alt=""
+      />
     ) : null;
 
   if (reverse)

--- a/src/pages/Contact/Contact.jsx
+++ b/src/pages/Contact/Contact.jsx
@@ -1,6 +1,7 @@
 import PageHeader from "./../../components/PageHeader/PageHeader";
 import ValueProp from "./../../components/ValueProp/ValueProp";
-import styles from "./../../components/AppNav/AppNav.module.css";
+import navStyles from "./../../components/AppNav/AppNav.module.css";
+import styles from "./Contact.module.css";
 
 function Contact() {
   return (
@@ -12,19 +13,20 @@ function Contact() {
         }
       />
       <ValueProp
+        mediaClassName={styles.mapMedia}
         iframe={
           <iframe
             width="100%"
             height="100%"
             src="https://www.openstreetmap.org/export/embed.html?bbox=-74.94414925575258%2C40.227457077182606%2C-74.93138194084169%2C40.23337095408929&amp;layer=hot&amp;marker=40.230414080185014%2C-74.93776559829712"
-            style={{ border: "1px solid black" }}
+            className={styles.mapFrame}
           />
         }
       >
         <div>
           <h3>How to reach us:</h3>
           <ul
-            className={`${styles.links} ${styles.linksVert} ${styles.socials}`}
+            className={`${navStyles.links} ${navStyles.linksVert} ${navStyles.socials}`}
           >
             <li>
               <a href="Tel: (215) 968-3791">(215) 968-3791</a>
@@ -32,7 +34,7 @@ function Contact() {
             <li>
               <a href="mailTo:burnsauto19@gmail.com">burnsauto19@gmail.com</a>
             </li>
-            <li className={styles.noMargin}>
+            <li className={navStyles.noMargin}>
               <a
                 href="https://maps.app.goo.gl/XPAXPgE9K1cnejQG6"
                 target="_blank"
@@ -42,16 +44,16 @@ function Contact() {
                 Newtown, PA 18940
               </a>
             </li>
-            <div className={styles.socialsInner}>
+            <div className={navStyles.socialsInner}>
               <a
-                className={styles.socialLink}
+                className={navStyles.socialLink}
                 href="https://www.facebook.com/BurnsAutoRepair19/"
                 target="_blank"
               >
                 <i className="fa-brands fa-facebook-f"></i>
               </a>
               <a
-                className={styles.socialLink}
+                className={navStyles.socialLink}
                 href="https://www.instagram.com/burnsautorepair/"
                 target="_blank"
               >
@@ -59,6 +61,9 @@ function Contact() {
               </a>
             </div>
           </ul>
+          <p className={styles.contactNote}>
+            Or stop by and we'd be happy to help you in person.
+          </p>
         </div>
       </ValueProp>
     </main>

--- a/src/pages/Contact/Contact.module.css
+++ b/src/pages/Contact/Contact.module.css
@@ -1,0 +1,20 @@
+.mapMedia {
+  width: 100% !important;
+  height: auto !important;
+  aspect-ratio: 1 / 1;
+  min-height: 360px;
+  margin: 2rem auto !important;
+}
+
+.mapFrame {
+  width: 100%;
+  height: 100%;
+  border: 1px solid #0d0d0d;
+  border-radius: 16px;
+}
+
+.contactNote {
+  margin-top: 1.5rem;
+  font-size: 1.05rem;
+  color: #3b3b3b;
+}


### PR DESCRIPTION
### Motivation

- Make the embedded map on the Contact page larger and more square to better match the page layout and be more useful to visitors.
- Add a friendly in-person invitation to the contact methods so visitors know they can stop by the shop.
- Allow pages to apply page-specific media styles to `ValueProp` so embedded media (maps, images, etc.) can be tuned without changing the shared component.

### Description

- Add an optional `mediaClassName` prop to `ValueProp` and apply it to the media container so callers can pass page-specific classes.
- Update the Contact page to pass `mediaClassName`, switch to a local `Contact.module.css`, and add the in-person helper sentence.
- Replace some style references to use the existing navigation styles as `navStyles` to avoid name collisions in the Contact page markup.
- Add `src/pages/Contact/Contact.module.css` with `.mapMedia`, `.mapFrame`, and `.contactNote` to control map aspect-ratio, frame, and the helper text presentation.

### Testing

- Ran `npm run dev -- --host 0.0.0.0 --port 4173` which started Vite but the run reported a parse error in an unrelated file (`src/components/AppNav/AppNav.jsx`) and therefore the dev server diagnostics showed a failure.
- Ran an automated Playwright script that navigated to `/contact` and produced a screenshot of the updated Contact page, which completed successfully and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a01301f4833088c97fbc764e2211)